### PR TITLE
Use relative "1 week" expression for exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "uv_build"
 [tool.uv]
 # Mitigate supply chain attacks by excluding too new packages.
 # https://docs.astral.sh/uv/reference/settings/#exclude-newer
-exclude-newer = "2026-03-13T00:00:00Z"
+exclude-newer = "1 week"
 
 [tool.pyright]
 # Explicitly set the type checking mode to "standard" for compatibility with Pylance.

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.12.13"
 
 [options]
-exclude-newer = "2026-03-13T00:00:00Z"
+exclude-newer = "2026-03-27T14:38:25.147434485Z"
+exclude-newer-span = "P1W"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
Change the `exclude-newer` setting from a hardcoded date to the relative expression `"1 week"`.

## Changes

- `pyproject.toml`: Set `exclude-newer = "1 week"`
- `uv.lock`: Regenerated with `uv lock` (records `exclude-newer-span = "P1W"`)

Each time `uv lock` is run, the timestamp is automatically calculated as one week before the current time.

https://claude.ai/code/session_019n2tQ6gnejgFqmrHJbSbxA